### PR TITLE
Remove use of Discourse.Site

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,4 +1,6 @@
 <script type="text/discourse-plugin" version="0.8.7">
+    const Site = require("discourse/models/site");
+
     api.registerConnectorClass('user-profile-primary', 'custom-profile-link', {
       setupComponent(args, component) {
         component.set('customProfileLink', args.model.get('customProfileLink'));
@@ -15,7 +17,7 @@
       customProfileLink: function() {
           const fieldName = settings.custom_profile_link_user_field;
           
-          const siteUserFields = Discourse.Site.currentProp('user_fields');
+          const siteUserFields = Site.currentProp('user_fields');
           if (Ember.isEmpty(siteUserFields)) return null;
           
           const field = siteUserFields.filterBy('name', fieldName)[0]


### PR DESCRIPTION
This API has been deprecated, and will be removed in a future version of Discourse